### PR TITLE
Modernize code base

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "tools/optional-lite"]
-	path = tools/optional-lite
-	url = https://github.com/martinmoene/optional-lite.git
-    branch = master

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,51 +1,72 @@
-cmake_minimum_required (VERSION 3.5)
+cmake_minimum_required (VERSION 3.23)
 
-set (CMAKE_CXX_STANDARD 17)
-set (CMAKE_CXX_STANDARD_REQUIRED ON)
+if(NOT DEFINED CMAKE_CXX_STANDARD)
+    set (CMAKE_CXX_STANDARD 17)
+    set (CMAKE_CXX_STANDARD_REQUIRED ON)
+endif()
+
 set (CMAKE_CXX_EXTENSIONS OFF)
 
-project (mpi4cpp)
-
-# set location of libraries
-set (CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/lib)
-
-
-
-##################################################
-# dependencies
-
-# fmt preinstallation fails with intel compilers
-#FIND_PACKAGE (FMT REQUIRED)
-#INCLUDE_DIRECTORIES ( "$ENV{FMT_INCLUDE_DIR}" )
-
-
-# hpc stuff 
-find_package (MPI)
-
-
-
-##################################################
-# targets build
-
-#-------------------------------------------------- 
-# Warning flags based on the compiler
-set (WARNING_FLAGS
-    $<$<CXX_COMPILER_ID:GNU>:
-        -Wall -Wextra -Wpedantic
-    >
-    $<$<CXX_COMPILER_ID:Clang>:
-        -Wall -Wextra -Wpedantic -Wno-missing-braces -g
-    >
+project (
+    mpi4cpp
+    VERSION 0.1.0
+    DESCRIPTION "C++ MPI wrapper library."
+    HOMEPAGE_URL "https://github.com/hel-astro-lab"
+    LANGUAGES CXX
 )
 
-#-------------------------------------------------- 
+add_library (mpi4cpp)
 
-include_directories( ${CMAKE_CURRENT_SOURCE_DIR}/include )
-include_directories( ${CMAKE_CURRENT_SOURCE_DIR}/tools/optional-lite/include )
+set_target_properties(mpi4cpp PROPERTIES VERSION ${PROJECT_VERSION})
+set_target_properties(mpi4cpp PROPERTIES LINKER_LANGUAGE CXX)
 
+target_include_directories (mpi4cpp PUBLIC "${PROJECT_SOURCE_DIR}/include")
+target_sources (
+    mpi4cpp
+    PUBLIC FILE_SET
+           all_headers
+           TYPE
+           HEADERS
+           BASE_DIRS
+           ${PROJECT_SOURCE_DIR}/include/
+           FILES
+           ./include/mpi4cpp/communicator.h
+           ./include/mpi4cpp/communicator_impl.h
+           ./include/mpi4cpp/datatype_fwd.h
+           ./include/mpi4cpp/datatype.h
+           ./include/mpi4cpp/environment.h
+           ./include/mpi4cpp/environment_impl.h
+           ./include/mpi4cpp/exception.h
+           ./include/mpi4cpp/mpi.h
+           ./include/mpi4cpp/nonblocking.h
+           ./include/mpi4cpp/nonblocking_impl.h
+           ./include/mpi4cpp/point2point_impl.h
+           ./include/mpi4cpp/request.h
+           ./include/mpi4cpp/request_impl.h
+           ./include/mpi4cpp/status.h
+           ./include/mpi4cpp/status_impl.h
+           ./include/mpi4cpp/detail/mpi_datatype_cache.h
+           ./include/mpi4cpp/detail/mpi_datatype_cache_impl.h
+           ./include/mpi4cpp/detail/mpl.h
+)
 
-enable_testing()
-#add_subdirectory(test EXCLUDE_FROM_ALL)
-add_subdirectory(test)
+# Use phony target for handling targets.
+add_library (mpi4cpp_warnings INTERFACE)
+target_compile_options (mpi4cpp_warnings
+    INTERFACE
+    $<$<CXX_COMPILER_ID:GNU>:-Wall -Wextra -Wpedantic>
+    $<$<CXX_COMPILER_ID:Clang>:-Wall -Wextra -Wpedantic -Wno-missing-braces>
+)
 
+find_package (MPI)
 
+target_link_libraries (mpi4cpp PUBLIC MPI::MPI_CXX PRIVATE mpi4cpp_warnings)
+
+if (PROJECT_IS_TOP_LEVEL)
+    # Declares ENABLE_TESTING option (default: ON).
+    include(CTest)
+    if (BUILD_TESTING)
+        message (STATUS "Enabling tests...")
+        add_subdirectory (test)
+    endif ()
+endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,7 @@ find_package (MPI)
 target_link_libraries (mpi4cpp PUBLIC MPI::MPI_CXX PRIVATE mpi4cpp_warnings)
 
 if (PROJECT_IS_TOP_LEVEL)
-    # Declares ENABLE_TESTING option (default: ON).
+    # Declares BUILD_TESTING option (default: ON).
     include(CTest)
     if (BUILD_TESTING)
         message (STATUS "Enabling tests...")

--- a/include/mpi4cpp/communicator.h
+++ b/include/mpi4cpp/communicator.h
@@ -1,7 +1,6 @@
 #pragma once
 
 //#include <optional>
-//#include "nonstd/optional.hpp"
 
 #include <vector>
 #include <iterator>

--- a/include/mpi4cpp/environment.h
+++ b/include/mpi4cpp/environment.h
@@ -1,17 +1,12 @@
 #pragma once
 
 #include <string>
-//#include <optional>
-#include <nonstd/optional.hpp>
+#include <optional>
 
 #include "mpi4cpp/detail/mpi_datatype_cache.h"
 
 
 namespace mpi4cpp { namespace mpi {
-
-using nonstd::optional;
-using nonstd::nullopt;
-
 
   namespace threading {
 /** @brief specify the supported threading level.
@@ -149,14 +144,14 @@ class environment {
    *
    *  If there is a host process, this routine returns the rank of
    *  that process. Otherwise, it returns an empty @c
-   *  optional<int>. MPI does not define the meaning of a "host"
+   *  std::optional<int>. MPI does not define the meaning of a "host"
    *  process: consult the documentation for the MPI
    *  implementation. This routine examines the @c MPI_HOST attribute
    *  of @c MPI_COMM_WORLD.
    *
    *  @returns The rank of the host process, if one exists.
    */
-  static optional<int> host_rank();
+  static std::optional<int> host_rank();
 
   /** Retrieves the rank of a process that can perform input/output.
    *
@@ -172,7 +167,7 @@ class environment {
    *  any_source if every process can perform I/O, or no value if no
    *  process can perform I/O.
    */
-  static optional<int> io_rank();
+  static std::optional<int> io_rank();
 
   /** Retrieve the name of this processor.
    *

--- a/include/mpi4cpp/environment_impl.h
+++ b/include/mpi4cpp/environment_impl.h
@@ -6,13 +6,10 @@
 #include <cassert>
 #include <string>
 #include <ostream>
+#include <optional>
 
 
 namespace mpi4cpp { namespace mpi {
-
-using nonstd::optional;
-using nonstd::nullopt;
-
 
 inline environment::environment(bool abort_on_exception)
   : 
@@ -117,7 +114,7 @@ environment::collectives_tag()
 }
 
 
-inline optional<int> 
+inline std::optional<int> 
 environment::host_rank()
 {
   int* host;
@@ -126,12 +123,12 @@ environment::host_rank()
   MPI_CHECK_RESULT(MPI_Comm_get_attr,
                          (MPI_COMM_WORLD, MPI_HOST, &host, &found));
   if ((found == 0) || *host == MPI_PROC_NULL)
-    return optional<int>();
+    return std::optional<int>();
   else
     return *host;
 }
 
-inline optional<int> 
+inline std::optional<int> 
 environment::io_rank()
 {
   int* io;
@@ -140,7 +137,7 @@ environment::io_rank()
   MPI_CHECK_RESULT(MPI_Comm_get_attr,
                          (MPI_COMM_WORLD, MPI_IO, &io, &found));
   if ((found == 0) || *io == MPI_PROC_NULL)
-    return optional<int>();
+    return std::optional<int>();
   else
     return *io;
 }

--- a/include/mpi4cpp/nonblocking.h
+++ b/include/mpi4cpp/nonblocking.h
@@ -11,8 +11,7 @@
 #include <utility>   // for std::pair
 #include <algorithm> // for iter_swap, reverse
 #include <cassert>
-//#include <optional>
-#include "nonstd/optional.hpp"
+#include <optional>
 
 #include "request.h"
 #include "status.h"
@@ -20,10 +19,6 @@
 
 
 namespace mpi4cpp { namespace mpi {
-
-  using nonstd::optional;
-  using nonstd::nullopt;
-
 
 /** 
  *  @brief Wait until any non-blocking request has completed.
@@ -59,7 +54,7 @@ wait_any(ForwardIterator first, ForwardIterator last)
   while (true) {
     // Check if we have found a completed request. If so, return it.
     if (current->active()) {
-      optional<status> result = current->test();
+      std::optional<status> result = current->test();
       if (bool(result)) {
         return std::make_pair(*result, current);
       }
@@ -135,22 +130,22 @@ wait_any(ForwardIterator first, ForwardIterator last)
  *  @returns If any outstanding requests have completed, a pair
  *  containing the status object that corresponds to the completed
  *  operation and the iterator referencing the completed
- *  request. Otherwise, an empty @c optional<>.
+ *  request. Otherwise, an empty @c std::optional<>.
  */
 template<typename ForwardIterator>
-optional<std::pair<status, ForwardIterator> >
+std::optional<std::pair<status, ForwardIterator> >
 test_any(ForwardIterator first, ForwardIterator last)
 {
   while (first != last) {
     // Check if we have found a completed request. If so, return it.
-    if (optional<status> result = first->test()) {
+    if (std::optional<status> result = first->test()) {
       return std::make_pair(*result, first);
     }
     ++first;
   }
 
   // We found nothing
-  return optional<std::pair<status, ForwardIterator> >();
+  return std::optional<std::pair<status, ForwardIterator> >();
 }
 
 /** 
@@ -193,7 +188,7 @@ wait_all(ForwardIterator first, ForwardIterator last, OutputIterator out)
     difference_type idx = 0;
     for (ForwardIterator current = first; current != last; ++current, ++idx) {
       if (!completed[idx]) {
-        if (optional<status> stat = current->test()) {
+        if (std::optional<status> stat = current->test()) {
           // This outstanding request has been completed. We're done.
           results[idx] = *stat;
           completed[idx] = true;
@@ -261,7 +256,7 @@ wait_all(ForwardIterator first, ForwardIterator last)
     difference_type idx = 0;
     for (ForwardIterator current = first; current != last; ++current, ++idx) {
       if (!completed[idx]) {
-        if (optional<status> stat = current->test()) {
+        if (std::optional<status> stat = current->test()) {
           // This outstanding request has been completed.
           completed[idx] = true;
           --num_outstanding_requests;
@@ -323,12 +318,12 @@ wait_all(ForwardIterator first, ForwardIterator last)
  *
  *  @returns If an @p out parameter was provided, the value @c out
  *  after all of the @c status objects have been emitted (if all
- *  requests were completed) or an empty @c optional<>. If no @p out
+ *  requests were completed) or an empty @c std::optional<>. If no @p out
  *  parameter was provided, returns @c true if all requests have
  *  completed or @c false otherwise.
  */
 template<typename ForwardIterator, typename OutputIterator>
-optional<OutputIterator>
+std::optional<OutputIterator>
 test_all(ForwardIterator first, ForwardIterator last, OutputIterator out)
 {
   std::vector<MPI_Request> requests;
@@ -336,7 +331,7 @@ test_all(ForwardIterator first, ForwardIterator last, OutputIterator out)
     // If we have a non-trivial request, then no requests can be
     // completed.
     if (!first->trivial()) {
-      return optional<OutputIterator>();
+      return std::optional<OutputIterator>();
     }
     requests.push_back(*first->trivial());
   }
@@ -353,7 +348,7 @@ test_all(ForwardIterator first, ForwardIterator last, OutputIterator out)
     }
     return out;
   } else {
-    return optional<OutputIterator>();
+    return std::optional<OutputIterator>();
   }
 }
 
@@ -425,7 +420,7 @@ wait_some(BidirectionalIterator first, BidirectionalIterator last,
   BidirectionalIterator start_of_completed = last;
   while (true) {
     // Check if we have found a completed request. 
-    if (optional<status> result = current->test()) {
+    if (std::optional<status> result = current->test()) {
       using std::iter_swap;
 
       // Emit the resulting status object
@@ -544,7 +539,7 @@ wait_some(BidirectionalIterator first, BidirectionalIterator last)
   BidirectionalIterator start_of_completed = last;
   while (true) {
     // Check if we have found a completed request. 
-    if (optional<status> result = current->test()) {
+    if (std::optional<status> result = current->test()) {
       using std::iter_swap;
 
       // We're expanding the set of completed requests
@@ -660,7 +655,7 @@ test_some(BidirectionalIterator first, BidirectionalIterator last,
   BidirectionalIterator start_of_completed = last;
   while (current != start_of_completed) {
     // Check if we have found a completed request. 
-    if (optional<status> result = current->test()) {
+    if (std::optional<status> result = current->test()) {
       using std::iter_swap;
 
       // Emit the resulting status object
@@ -697,7 +692,7 @@ test_some(BidirectionalIterator first, BidirectionalIterator last)
   BidirectionalIterator start_of_completed = last;
   while (current != start_of_completed) {
     // Check if we have found a completed request. 
-    if (optional<status> result = current->test()) {
+    if (std::optional<status> result = current->test()) {
       using std::iter_swap;
 
       // We're expanding the set of completed requests

--- a/include/mpi4cpp/nonblocking_impl.h
+++ b/include/mpi4cpp/nonblocking_impl.h
@@ -2,10 +2,9 @@
 
 #include "request.h"
 
-namespace mpi4cpp { namespace mpi {
+#include <optional>
 
-using nonstd::optional;
-using nonstd::nullopt;
+namespace mpi4cpp { namespace mpi {
 
 //--------------------------------------------------
 
@@ -136,7 +135,7 @@ namespace detail {
 }
 
 template<typename T, class A>
-inline optional<status> 
+inline std::optional<status> 
 request::handle_dynamic_primitive_array_irecv(request* self, request_action action)
 {
   typedef detail::dynamic_array_irecv_data<T,A> data_t;
@@ -180,7 +179,7 @@ request::handle_dynamic_primitive_array_irecv(request* self, request_action acti
                                 self->m_requests + 1));
 
       } else
-        return optional<status>(); // We have not finished yet
+        return std::optional<status>(); // We have not finished yet
     } 
 
     // Check if we have received the message data
@@ -188,9 +187,9 @@ request::handle_dynamic_primitive_array_irecv(request* self, request_action acti
     if (flag) {
       return stat;
     } else 
-      return optional<status>();
+      return std::optional<status>();
   } else {
-    return optional<status>();
+    return std::optional<status>();
   }
 }
 

--- a/include/mpi4cpp/request.h
+++ b/include/mpi4cpp/request.h
@@ -1,13 +1,9 @@
 #pragma once
 
-//#include <optional>
-#include "nonstd/optional.hpp"
 #include <functional>
+#include <optional>
 
 namespace mpi4cpp { namespace mpi {
-
-using nonstd::optional;
-using nonstd::nullopt;
 
 class status;
 class communicator;
@@ -56,11 +52,11 @@ class request
    *  Determine whether the communication associated with this request
    *  has completed successfully. If so, returns the @c status object
    *  describing the communication. Otherwise, returns an empty @c
-   *  optional<> to indicate that the communication has not completed
+   *  std::optional<> to indicate that the communication has not completed
    *  yet. Note that once @c test() returns a @c status object, the
    *  request has completed and @c wait() should not be called.
    */
-  optional<status> test();
+  std::optional<status> test();
 
   /**
    *  Cancel a pending communication, assuming it has not already been
@@ -103,27 +99,27 @@ class request
 
  private:
   enum request_action { ra_wait, ra_test, ra_cancel };
-  using handler_type = optional<status> (*)(request *, request_action);
+  using handler_type = std::optional<status> (*)(request *, request_action);
 
   /**
    * Handles the non-blocking receive of a serialized value.
    */
   template<typename T>
-  static optional<status> 
+  static std::optional<status> 
   handle_serialized_irecv(request* self, request_action action);
 
   /**
    * Handles the non-blocking receive of an array of  serialized values.
    */
   template<typename T>
-  static optional<status> 
+  static std::optional<status> 
   handle_serialized_array_irecv(request* self, request_action action);
 
    /**
    * Handles the non-blocking receive of a dynamic array of primitive values.
    */
   template<typename T, class A>
-  static optional<status> 
+  static std::optional<status> 
   handle_dynamic_primitive_array_irecv(request* self, request_action action);
 
  private:

--- a/include/mpi4cpp/request_impl.h
+++ b/include/mpi4cpp/request_impl.h
@@ -1,14 +1,12 @@
 #pragma once
 
 #include <exception>
+#include <optional>
 
 #include "exception.h"
 
 
 namespace mpi4cpp { namespace mpi {
-
-using nonstd::optional;
-using nonstd::nullopt;
 
 
 inline request::request()
@@ -80,7 +78,7 @@ request::wait()
 }
 
 
-inline optional<status> 
+inline std::optional<status> 
 request::test()
 {
   if (m_handler != nullptr) {
@@ -95,7 +93,7 @@ request::test()
     status result;
     int flag = 0;
     MPI_CHECK_RESULT(MPI_Test, (&m_requests[0], &flag, &result.m_status));
-    return flag != 0? optional<status>(result) : optional<status>();
+    return flag != 0? std::optional<status>(result) : std::optional<status>();
   } else {
     // This request is a send of a serialized type, broken into two
     // separate messages. We only get a result if both complete.
@@ -126,7 +124,7 @@ request::test()
       result.m_status = stats[1];
       return result;
     } else {
-      return optional<status>();
+      return std::optional<status>();
     }
   }
 }

--- a/include/mpi4cpp/status.h
+++ b/include/mpi4cpp/status.h
@@ -43,12 +43,12 @@ class status
    * message. The type @c T must have an associated data type, i.e.,
    * @c is_mpi_datatype<T> must derive @c mpl::true_. In cases where
    * the type @c T does not match the transmitted type, this routine
-   * will return an empty @c optional<int>.
+   * will return an empty @c std::optional<int>.
    *
    * @returns the number of @c T elements in the message, if it can be
    * determined.
    */
-  //template<typename T> optional<int> count() const;
+  //template<typename T> std::optional<int> count() const;
 
 
   /**

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,19 +1,14 @@
-project (tests)
-
 function(add_mpi_test name no_mpi_proc)
-    #include_directories(${MY_TESTING_INCLUDES})
     add_executable(${name} test_${name}.c++)
 
-    target_link_libraries(${name} PRIVATE MPI::MPI_CXX)
+    target_link_libraries(${name} PRIVATE mpi4cpp mpi4cpp_warnings)
 
-    target_compile_options(${name} PRIVATE ${WARNING_FLAGS})
     set(test_parameters ${MPIEXEC_NUMPROC_FLAG} ${no_mpi_proc} "./${name}")
-
     add_test(NAME ${name} COMMAND ${MPIEXEC} ${test_parameters})
 endfunction(add_mpi_test)
 
 
-set (TEST_FILES 
+set (TEST_FILES
      init
      send_recv_nodata
      send_recv
@@ -24,7 +19,7 @@ set (TEST_FILES
      isend_irecv_types
      iarrays
      own_datatype
-     )
+)
 
 
 # add all tests

--- a/test/test_iarrays.c++
+++ b/test/test_iarrays.c++
@@ -17,24 +17,25 @@ template<typename T>
 bool test_carray(mpi::communicator& world)
 {
   mpi::request reqs[2];
-  T msg[NX];
+  T msg0[NX];
+  T msg1[NX];
 
   if (world.rank() == 0) {
-    for(int i=0; i<NX; i++) msg[i] = static_cast<T>(1);
-    reqs[0] = world.isend(1, 0, &msg[0], NX);
-    reqs[1] = world.irecv(1, 1, &msg[0], NX);
+    for(int i=0; i<NX; i++) msg0[i] = static_cast<T>(1);
+    reqs[0] = world.isend(1, 0, &msg0[0], NX);
+    reqs[1] = world.irecv(1, 1, &msg1[0], NX);
   } else {
-    for(int i=0; i<NX; i++) msg[i] = static_cast<T>(2);
-    reqs[0] = world.isend(0, 1, &msg[0], NX);
-    reqs[1] = world.irecv(0, 0, &msg[0], NX);
+    for(int i=0; i<NX; i++) msg1[i] = static_cast<T>(2);
+    reqs[0] = world.isend(0, 1, &msg1[0], NX);
+    reqs[1] = world.irecv(0, 0, &msg0[0], NX);
   }
 
   mpi::wait_all(reqs, reqs+2);
   
   if (world.rank() == 0) {
-    for(int i=0; i<NX; i++) assert(msg[i] == static_cast<T>(2) );
+    for(int i=0; i<NX; i++) assert(msg1[i] == static_cast<T>(2) );
   } else {
-    for(int i=0; i<NX; i++) assert(msg[i] == static_cast<T>(1) );
+    for(int i=0; i<NX; i++) assert(msg0[i] == static_cast<T>(1) );
   }
 
   return true;
@@ -47,24 +48,25 @@ template<typename T>
 bool test_array(mpi::communicator& world)
 {
   requests reqs(2);
-  std::array<T, NX> msg;
+  std::array<T, NX> msg0;
+  std::array<T, NX> msg1;
 
   if (world.rank() == 0) {
-    for(int i=0; i<NX; i++) msg[i] = static_cast<T>(1);
-    reqs[0] = world.isend(1, 0, &msg[0], NX);
-    reqs[1] = world.irecv(1, 1, &msg[0], NX);
+    for(int i=0; i<NX; i++) msg0[i] = static_cast<T>(1);
+    reqs[0] = world.isend(1, 0, &msg0[0], NX);
+    reqs[1] = world.irecv(1, 1, &msg1[0], NX);
   } else {
-    for(int i=0; i<NX; i++) msg[i] = static_cast<T>(2);
-    reqs[0] = world.isend(0, 1, &msg[0], NX);
-    reqs[1] = world.irecv(0, 0, &msg[0], NX);
+    for(int i=0; i<NX; i++) msg1[i] = static_cast<T>(2);
+    reqs[0] = world.isend(0, 1, &msg1[0], NX);
+    reqs[1] = world.irecv(0, 0, &msg0[0], NX);
   }
 
   mpi::wait_all(reqs.begin(), reqs.end());
   
   if (world.rank() == 0) {
-    for(int i=0; i<NX; i++) assert(msg[i] == static_cast<T>(2) );
+    for(int i=0; i<NX; i++) assert(msg1[i] == static_cast<T>(2) );
   } else {
-    for(int i=0; i<NX; i++) assert(msg[i] == static_cast<T>(1) );
+    for(int i=0; i<NX; i++) assert(msg0[i] == static_cast<T>(1) );
   }
 
   return true;
@@ -97,52 +99,11 @@ bool test_vector(mpi::communicator& world)
   }
 
   mpi::wait_all(reqs.begin(), reqs.end());
-  
+
   if (world.rank() == 0) {
-
-    for(int i=0; i<NX; i++) 
-        if(!(rmsg[i] == static_cast<T>(2))) std::cout << "Got erraneous value for rank 0 at :" << i << " : " << rmsg[i] << " vs " << static_cast<T>(2) << "\n";
-
     for(int i=0; i<NX; i++) assert(rmsg[i] == static_cast<T>(2) );
-    //std::cout << "rank " << world.rank() << " got message " << rmsg[0] << std::endl;
   } else {
-
-    for(int i=0; i<NX; i++) 
-        if(!(rmsg[i] == static_cast<T>(1))) std::cout << "Got erraneous value for rank 1 at :" << i << " : " << rmsg[i] << " vs " << static_cast<T>(1) << "\n";
-
-
     for(int i=0; i<NX; i++) assert(rmsg[i] == static_cast<T>(1) );
-    //std::cout << "rank " << world.rank() << " got message " << msg[0] << std::endl;
-  }
-
-  return true;
-}
-
-// std::vector
-template<typename T>
-bool test_vector_arr(mpi::communicator& world)
-{
-  requests reqs(2);
-
-  std::vector<T> msg;
-  msg.resize(NX);
-
-  if (world.rank() == 0) {
-    for(int i=0; i<NX; i++) msg[i] = static_cast<T>(1);
-    reqs[0] = world.isend(1, 0, &msg[0], NX);
-    reqs[1] = world.irecv(1, 1, &msg[0], NX);
-  } else {
-    for(int i=0; i<NX; i++) msg[i] = static_cast<T>(2);
-    reqs[0] = world.isend(0, 1, &msg[0], NX);
-    reqs[1] = world.irecv(0, 0, &msg[0], NX);
-  }
-
-  mpi::wait_all(reqs.begin(), reqs.end());
-  
-  if (world.rank() == 0) {
-    for(int i=0; i<NX; i++) assert(msg[i] == static_cast<T>(2) );
-  } else {
-    for(int i=0; i<NX; i++) assert(msg[i] == static_cast<T>(1) );
   }
 
   return true;
@@ -154,9 +115,8 @@ bool test_all_arrays(mpi::communicator& world)
   bool f1 = test_carray<T>(world);
   bool f2 = test_array<T> (world);
   bool f3 = test_vector<T>(world);
-  bool f4 = test_vector_arr<T>(world);
 
-  return f1 && f2 && f3 && f4;
+  return f1 && f2 && f3;
 }
 
 


### PR DESCRIPTION
- modernizes CMake usage
  - create new mpi4cpp cmake target (users don't have to manually add header directories)
  - add MPI to the new mpi4cpp target
  - add some project metadata (not sure of the version)
  - don't enable test if not toplevel project
  - minimum cmake version 3.05 -> 3.23 (enables usage of FILE_SET which is recommended practice)
- use std::optional
  - remove optional-lite
- remove UB from test (nonblocking send and receive happened from and to the same array which is race condition(?))